### PR TITLE
Update about page and remove company name

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=no, viewport-fit=cover">
-  <title>油井宏介について | BrightReach</title>
+  <title>油井宏介について</title>
   <link rel="stylesheet" href="common.css">
   <link rel="stylesheet" href="index.css">
   <link rel="stylesheet" href="profile.css">
@@ -27,7 +27,7 @@
         </div>
         <div class="hero-text">
           <h2>油井宏介について</h2>
-          <p>BrightReachファイナンシャルプランナー<br><b>油井宏介（ゆい こうすけ）</b></p>
+          <p>ファイナンシャルプランナー<br><b>油井宏介（ゆい こうすけ）</b></p>
         </div>
       </div>
     </section>
@@ -40,7 +40,10 @@
         「何から相談していいかわからない」「自分に合ったプランが知りたい」——そんな方こそ、ぜひお気軽にご相談ください。<br>
         <br>
         専門知識と誠実なヒアリングで、<br>
-        あなたの未来に寄り添う"身近なパートナー"でありたいと考えています。
+        あなたの未来に寄り添う"身近なパートナー"でありたいと考えています。<br>
+        前職では法人融資や個人事業主向け融資を担当し、豊富な資金調達の実務経験を積んできました。<br>
+        住宅ローンアドバイザーの資格も保有しており、マイホーム購入や借り換えに関するご相談も承ります。<br>
+        人の人生に大きな影響を与えられる存在になることを目指し、日々研鑽を続けています。
       </p>
     </section>
 
@@ -79,7 +82,6 @@
     <section class="company-info fadein-section">
       <h2>会社情報（所属）</h2>
       <table>
-        <tr><th>会社名</th><td>株式会社BrightReach（ブライトリーチ）</td></tr>
         <tr><th>所在地</th><td>〒104-0043 東京都中央区湊1-8-11 八丁堀エイトビル6階</td></tr>
         <tr><th>代表者</th><td>代表取締役社長　青柳 雄太郎</td></tr>
         <tr><th>設立</th><td>2012年9月（創業）</td></tr>

--- a/privacy.html
+++ b/privacy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=no, viewport-fit=cover">
-  <title>プライバシーポリシー | BrightReach</title>
+  <title>プライバシーポリシー</title>
   <link rel="stylesheet" href="common.css">
   <link rel="stylesheet" href="privacy.css">
 </head>
@@ -24,8 +24,8 @@
       <h2>個人情報保護方針</h2>
       <p>
         <b>このサイトは油井宏介が運営しています。</b><br>
-        株式会社BrightReach（以下、「当社」）は、お客様の個人情報の保護に万全を尽くします。<br>
-        当社ウェブサイトおよび各種サービスのご利用に際してお預かりする個人情報について、以下の方針に従い適切に取り扱います。
+        当サイトでは、お客様の個人情報の保護に万全を尽くします。<br>
+        ウェブサイトおよび各種サービスのご利用に際してお預かりする個人情報について、以下の方針に従い適切に取り扱います。
       </p>
     </section>
 
@@ -68,7 +68,7 @@
     <section class="policy-contact fadein-section">
       <h3>お問い合わせ窓口</h3>
       <p>
-        株式会社BrightReach　個人情報担当窓口<br>
+        個人情報担当窓口<br>
         〒104-0043 東京都中央区湊1-8-11 八丁堀エイトビル6階<br>
         E-mail: <a href="mailto:kosuke.yui@brightreach.co.jp">kosuke.yui@brightreach.co.jp</a><br>
         Tel: 03-6222-7277（受付時間 平日9:00～18:00）


### PR DESCRIPTION
## Summary
- hide company name references on about/privacy pages
- mention previous financing experience and housing loan adviser qualification

## Testing
- `git status --short`